### PR TITLE
Feature/component content

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,12 @@
+const path = require('path')
+exports.onCreateWebpackConfig = ({actions}) => {
+  actions.setWebpackConfig({
+    resolve: {
+      alias: {
+        '@components': path.resolve(__dirname, 'src/components'),
+        '@utilities': path.resolve(__dirname, 'src/utilities'),
+        '@static': path.resolve(__dirname, 'static')
+      }
+    }
+  })
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+
 module.exports = {
   transform: {
     '^.+\\.jsx?$': '<rootDir>/jest-preprocess.js',
@@ -5,6 +6,9 @@ module.exports = {
   moduleNameMapper: {
     '.+\\.(css|styl|less|sass|scss)$': 'identity-obj-proxy',
     '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/file-mock.js',
+    '^@components(.*)$': '<rootDir>/src/components$1',
+    '^@utilities(.*)$': '<rootDir>/src/utilities$1',
+    '^@static(.*)$': '<rootDir>/src/static$1',
   },
   testPathIgnorePatterns: ['node_modules', '\\.cache', '<rootDir>.*/public'],
   transformIgnorePatterns: ['node_modules/(?!(gatsby)/)'],

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/utils/*": ["src/utilities/*"]
+    }
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,9 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@/components/*": ["src/components/*"],
-      "@/utils/*": ["src/utilities/*"]
-    }
-  }
-}

--- a/src/__tests__/Content.js
+++ b/src/__tests__/Content.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import Content from '@components/molecules/Content'
+describe('Content', () => {
+  it('renders correctly', () => {
+    const tree = renderer
+      .create(
+        <Content
+          title={'Content title.'}
+          titleTag="h3"
+          content="Text content..."
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/__tests__/Heading.js
+++ b/src/__tests__/Heading.js
@@ -1,0 +1,19 @@
+import React, {Fragment} from 'react'
+import renderer from 'react-test-renderer'
+import Heading from '../components/atoms/Heading'
+describe('Heading', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(
+      <Fragment>
+        <Heading>Default</Heading>
+        <Heading tag="h1">H1</Heading>
+        <Heading tag="h2">H2</Heading>
+        <Heading tag="h3">H3</Heading>
+        <Heading tag="h4">H4</Heading>
+        <Heading tag="h5">H5</Heading>
+        <Heading tag="h6">H6</Heading>
+      </Fragment>
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/__tests__/__snapshots__/Content.js.snap
+++ b/src/__tests__/__snapshots__/Content.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Content renders correctly 1`] = `
+<section
+  className="content"
+>
+  <h3
+    className="contentHeading"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Content title.",
+      }
+    }
+  />
+  <div
+    className="text"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Text content...",
+      }
+    }
+  />
+</section>
+`;

--- a/src/__tests__/__snapshots__/Heading.js.snap
+++ b/src/__tests__/__snapshots__/Heading.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading renders correctly 1`] = `
+Array [
+  <h1
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Default",
+      }
+    }
+  />,
+  <h1
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "H1",
+      }
+    }
+  />,
+  <h2
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "H2",
+      }
+    }
+  />,
+  <h3
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "H3",
+      }
+    }
+  />,
+  <h4
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "H4",
+      }
+    }
+  />,
+  <h5
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "H5",
+      }
+    }
+  />,
+  <h6
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "H6",
+      }
+    }
+  />,
+]
+`;

--- a/src/components/atoms/Heading/index.js
+++ b/src/components/atoms/Heading/index.js
@@ -1,4 +1,4 @@
-import createMarkup from '@/utils/createMarkup'
+import createMarkup from '@utilities/createMarkup'
 import PropTypes from 'prop-types'
 import React from 'react'
 

--- a/src/components/atoms/Heading/index.js
+++ b/src/components/atoms/Heading/index.js
@@ -1,4 +1,4 @@
-import createMarkup from '@/functions/createMarkup'
+import createMarkup from '@/utils/createMarkup'
 import PropTypes from 'prop-types'
 import React from 'react'
 

--- a/src/components/atoms/Heading/index.js
+++ b/src/components/atoms/Heading/index.js
@@ -1,0 +1,33 @@
+import createMarkup from '@/functions/createMarkup'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export default function Heading({children, className, id, tag}) {
+  if (typeof children === 'string') {
+    return React.createElement(tag, {
+      className,
+      id,
+      dangerouslySetInnerHTML: createMarkup(children)
+    })
+  } else {
+    return React.createElement(
+      tag,
+      {
+        className,
+        id
+      },
+      children
+    )
+  }
+}
+
+Heading.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  className: PropTypes.string,
+  id: PropTypes.string,
+  tag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
+}
+
+Heading.defaultProps = {
+  tag: 'h1'
+}

--- a/src/components/atoms/Link/index.js
+++ b/src/components/atoms/Link/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import { Link as GatsbyLink } from 'gatsby'
+import {Link as GatsbyLink} from 'gatsby'
 import PropTypes from 'prop-types'
 
-export default function Link({ children, to, activeClassName, partiallyActive, ...other }) {
+export default function Link({children, to, activeClassName, partiallyActive, ...other}) {
   const internal = /^\/(?!\/)/.test(to)
 
   // Use Gatsby Link for internal links, and <a> for others

--- a/src/components/molecules/Content/Content.module.css
+++ b/src/components/molecules/Content/Content.module.css
@@ -1,0 +1,11 @@
+.content {
+  @apply font-sans mx-auto max-w-full md:max-w-2xl text-center p-8 md:p-10 lg:p-14;
+
+  & .contentHeading {
+    @apply text-primary-purple2 font-thin text-5xl md:text-6xl lg:text-7xl mb-4;
+  }
+
+  & .text {
+    @apply text-primary-purple1 font-thin text-lg;
+  }
+}

--- a/src/components/molecules/Content/index.js
+++ b/src/components/molecules/Content/index.js
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import createMarkup from '../../../utilities/createMarkup'
+import createMarkup from '@utilities/createMarkup'
+// import Heading from '@components/atoms/Heading'
+import Heading from '@components/atoms/Heading'
 
-export default function Content({content, title}) {
+export default function Content({content, title, titleTag}) {
   return (
     <section>
-      {title && <h1>{title}</h1>}
+      {title && <Heading tag={titleTag}>{title}</Heading>}
       {content && <div dangerouslySetInnerHTML={ createMarkup(content) } />}
     </section>
   )
@@ -14,4 +16,9 @@ export default function Content({content, title}) {
 Content.propTypes = {
   content: PropTypes.string,
   title: PropTypes.string,
+  titleTag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
 }
+
+// Content.defaultProps = {
+//   titleTag: 'h2'
+// }

--- a/src/components/molecules/Content/index.js
+++ b/src/components/molecules/Content/index.js
@@ -2,12 +2,13 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import createMarkup from '@utilities/createMarkup'
 import Heading from '@components/atoms/Heading'
+import styles from './Content.module.css'
 
 export default function Content({content, title, titleTag}) {
   return (
-    <section>
-      {title && <Heading tag={titleTag}>{title}</Heading>}
-      {content && <div dangerouslySetInnerHTML={ createMarkup(content) } />}
+    <section className={styles.content}>
+      {title && <Heading className={styles.contentHeading} tag={titleTag}>{title}</Heading>}
+      {content && <div dangerouslySetInnerHTML={ createMarkup(content) } className={styles.text} />}
     </section>
   )
 }

--- a/src/components/molecules/Content/index.js
+++ b/src/components/molecules/Content/index.js
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import createMarkup from '../../../utilities/createMarkup'
+
+export default function Content({content, title}) {
+  return (
+    <section>
+      {title && <h1>{title}</h1>}
+      {content && <div dangerouslySetInnerHTML={ createMarkup(content) } />}
+    </section>
+  )
+}
+
+Content.propTypes = {
+  content: PropTypes.string,
+  title: PropTypes.string,
+}

--- a/src/components/molecules/Content/index.js
+++ b/src/components/molecules/Content/index.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import createMarkup from '@utilities/createMarkup'
-// import Heading from '@components/atoms/Heading'
 import Heading from '@components/atoms/Heading'
 
 export default function Content({content, title, titleTag}) {
@@ -19,6 +18,6 @@ Content.propTypes = {
   titleTag: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])
 }
 
-// Content.defaultProps = {
-//   titleTag: 'h2'
-// }
+Content.defaultProps = {
+  titleTag: 'h2'
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import * as React from 'react'
-import Layout from '../components/molecules/Layout'
-import Hero from '../components/molecules/Hero'
+import Layout from '@components/molecules/Layout'
+import Hero from '@components/molecules/Hero'
+import Content from '@components/molecules/Content'
 
 const IndexPage = () => {
   return (
@@ -9,6 +10,11 @@ const IndexPage = () => {
         title={'I\'m Mike England'}
         content={'Frontend Engineer / Designer / Motorcycle Enthusiast'}
         img={'./images/wcus2018-hall-track-1.jpg'}
+      />
+      <Content
+        title={ 'About Me' }
+        titleTag="h2"
+        content={ 'I\'m a Frontend Engineer at WebDevStudios and I\'m passionate about all things JavaScript. Building awesome websites, tools, and web applications is my passion!' }
       />
     </Layout>
   )

--- a/src/utilities/createMarkup.js
+++ b/src/utilities/createMarkup.js
@@ -1,0 +1,9 @@
+/**
+ * Handle content that contains HTML.
+ *
+ * @param  {Array} props Array of JSX Objects.
+ * @return String of HTML.
+ */
+export default function createMarkup(props) {
+  return {__html: props}
+}


### PR DESCRIPTION
Setup Content component for displaying basic text content.

Updates
- Linter fixes
- Setup `Heading` component with dynamic tag features
- Setup `Content` component based on original `ContentSection` component
- Add path aliases for Gatsby so that paths could be simplified. Note: I only updated paths affected by this PR.
- Setup styles for Content component
- Update Jest aliases to point to new paths
- Setup Snapshot for Content
- Setup Snapshot for Header