### PR TITLE
Add unit test for createMarkup

### DIFF
--- a/src/utilities/__tests__/createMarkup.js
+++ b/src/utilities/__tests__/createMarkup.js
@@ -1,0 +1,12 @@
+import createMarkup from '../createMarkup'
+
+test('createMarkup returns correct markup.', () => {
+  const dangerousMarkup = '<p>HTML Content with markup.</p>'
+  const renderDangerousMarkup = jest.fn(markup => markup.__html)
+
+  // Mock function by returning Object data.
+  renderDangerousMarkup(createMarkup(dangerousMarkup))
+
+  // Expect returned Object data to match original content.
+  expect(renderDangerousMarkup).toHaveReturnedWith('<p>HTML Content with markup.</p>')
+})


### PR DESCRIPTION
This test verifies that dangerousMarkup passed in, returns non-escaped
HTML.

<img width="712" alt="Screen Shot 2021-01-11 at 11 03 44 PM" src="https://user-images.githubusercontent.com/25035900/104268885-f7737800-5462-11eb-8f8b-a768125deb7b.png">
<img width="577" alt="Screen Shot 2021-01-11 at 11 03 59 PM" src="https://user-images.githubusercontent.com/25035900/104268886-f80c0e80-5462-11eb-94f4-f5f2f350e248.png">
