### PR TITLE
Fix/safari icon bug

### DIFF
--- a/src/components/molecules/SocialLinks/SocialLinks.module.css
+++ b/src/components/molecules/SocialLinks/SocialLinks.module.css
@@ -35,6 +35,10 @@
       height: 2rem;
       width: 2rem;
     }
+
+    & svg {
+      @apply w-full h-full;
+    }
   }
 
   & .label {


### PR DESCRIPTION
## Updates

Add height and width values to SocialLinks icons. This fixes issues with icons not displaying in IOS and Safari.