### PR TITLE
Hotfix/date format gql issue

### DIFF
--- a/content/blog/learning-git/stashing-your-code-with-a-description.mdx
+++ b/content/blog/learning-git/stashing-your-code-with-a-description.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Adding a Description to git stash'
-date: '2020-01-14T04:02:57'
-tags: 'git'
+title: Adding a Description to git stash
+date: 2020-01-14T04:02:57
+tags: git
 ---
 
 # Using git stash

--- a/content/blog/learning-js/destructuring-examples.mdx
+++ b/content/blog/learning-js/destructuring-examples.mdx
@@ -1,7 +1,7 @@
 ---
 title: ES6 Destructure Examples
-date: '2019-12-01T22:15:03.284Z'
-description: 'Notes that I took while learning about destructuring.'
+date: 2019-12-01T22:15:03.284Z
+description: Personal notes while learning about destructuring
 ---
 
 ## Simple Examples of Destructuring in Javascript
@@ -131,11 +131,8 @@ const colorPalette = [
 ]
 
 // Assigning new variables.
-const [
-  exmapleOne: 'red',
-  exampleTwo: 'orange',
-  exampleThree: 'yellow'
-] = colorPalette
+const [exmapleOne: 'red', exampleTwo: 'orange', exampleThree: 'yellow'] =
+  colorPalette
 
 console.log(red)
 console.log(orange)

--- a/content/blog/learning-the-github-cli.md
+++ b/content/blog/learning-the-github-cli.md
@@ -1,6 +1,6 @@
 ---
 title: Learning the GitHub CLI
-date: '2021-08-16T12:00:00Z'
+date: 2021-08-16T12:00:00Z
 tags: []
 ---
 

--- a/content/blog/mike-england-whats-new-2021.md
+++ b/content/blog/mike-england-whats-new-2021.md
@@ -1,7 +1,7 @@
 ---
 title: Mike England, What's new in 2021
-date: '2021-04-06T12:51:30Z'
-description: 'Thoughts and career goals for 2021'
+date: 2021-04-06T12:51:30Z
+description: Thoughts and career goals for 2021
 ---
 
 # What's new in 2021

--- a/content/blog/preventing-line-breaks-in-richtext-component.md
+++ b/content/blog/preventing-line-breaks-in-richtext-component.md
@@ -1,6 +1,6 @@
 ---
 title: Preventing line break elements in the RichText component
-date: '2021-05-13T17:00:00Z'
+date: 2021-05-13T17:00:00Z
 tags: []
 ---
 
@@ -18,13 +18,13 @@ Taking a look at [onSplit](https://github.com/WordPress/gutenberg/tree/trunk/pac
 
 Due to the codependent relationship of `onSplit` and `onReplace` we must include the [onReplace](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/rich-text#onreplace-blocks-array--function) property and pass it an empty function as well.
 
-*UPDATE 5-25-21: The `multiline` prop on the RichText component must be set to `false` for this feature to work. The `multiline` prop defaults to `false` so it's not explicitly required. Any value other than `false` will cause the return disable not to work.*
+_UPDATE 5-25-21: The `multiline` prop on the RichText component must be set to `false` for this feature to work. The `multiline` prop defaults to `false` so it's not explicitly required. Any value other than `false` will cause the return disable not to work._
 
 ```js
 <RichText
   multiline={false} // Not required, this is the default value.
-  onReplace={()=>{}}
-  onSplit={()=>{}}
+  onReplace={() => {}}
+  onSplit={() => {}}
 />
 ```
 

--- a/src/components/molecules/Posts/index.js
+++ b/src/components/molecules/Posts/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Heading from '@components/atoms/Heading'
 import TextLink from '@components/atoms/TextLink'
 import styles from './Posts.module.css'
+import formatBlogDate from '@utilities/formatBlogDate'
 
 // TODO Refactor this component with more strict props.
 // TODO Create snapshot test.
@@ -30,7 +31,7 @@ export default function Posts({posts}) {
                   </TextLink>
                 </Heading>
               }
-              {date && <small className={styles.date}>{date}</small>}
+              {date && <small className={styles.date}>{formatBlogDate(date)}</small>}
               {excerpt && <p className={styles.content}>{excerpt}</p>}
             </article>
           )

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -36,7 +36,7 @@ export const pageQuery = graphql`
         excerpt
         frontmatter {
           title
-          date(formatString: "MMMM DD, YYYY")
+          date
         }
         slug
       }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -8,6 +8,7 @@ import SEO from '@components/atoms/SEO'
 import PostContent from '@components/molecules/PostContent'
 import PostHeader from '@components/molecules/PostHeader'
 import PostNavigation from '@components/molecules/PostNavigation'
+import formatBlogDate from '@utilities/formatBlogDate'
 
 export default function BlogPostTemplate({data, pageContext}) {
   const post = data.mdx
@@ -21,7 +22,7 @@ export default function BlogPostTemplate({data, pageContext}) {
       />
       <PostHeader
         title={post.frontmatter.title}
-        content={post.frontmatter.date}
+        content={formatBlogDate(post.frontmatter.date)}
       />
       <PostContent>
         <MDXRenderer>{post.body}</MDXRenderer>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -56,7 +56,7 @@ export const pageQuery = graphql`
       body
       frontmatter {
         title
-        date(formatString: "MMMM DD, YYYY")
+        date
         description
       }
     }

--- a/src/utilities/formatBlogDate.js
+++ b/src/utilities/formatBlogDate.js
@@ -1,0 +1,12 @@
+import moment from 'moment'
+
+/**
+ * Format date using moment.
+ *
+ * @see https://momentjs.com/
+ * @param  {date} date to format.
+ * @return Formatted date.
+ */
+export default function formatBlogDate(date) {
+  return moment(date).format('MMMM DD, YYYY') ?? null
+}


### PR DESCRIPTION
Apply a hotfix to prevent a GQL error that causes builds to fail. This error is caused a change in a supported format that no longer works properly.

Note: This update includes a minor modification to the blog metadata areas. Since these files are markdown, they do not need to be wrapped in strings.

Before:
Date formats on the blog were handled with a GQL query.

After:
We just utilize a simple `moment` format.
