### PR TITLE
Fix/53 fix eslint build errors

### DIFF
--- a/src/components/atoms/TextLink/index.js
+++ b/src/components/atoms/TextLink/index.js
@@ -26,7 +26,7 @@ export default function TextLink({children, to, activeClassName, partiallyActive
   }
 }
 
-Link.propTypes = {
+TextLink.propTypes = {
   children: PropTypes.node.isRequired,
   partiallyActive: PropTypes.bool,
   to: PropTypes.string.isRequired,

--- a/src/components/atoms/TextLink/index.js
+++ b/src/components/atoms/TextLink/index.js
@@ -27,6 +27,7 @@ export default function TextLink({children, to, activeClassName, partiallyActive
 }
 
 TextLink.propTypes = {
+  activeClassName: PropTypes.string,
   children: PropTypes.node.isRequired,
   partiallyActive: PropTypes.bool,
   to: PropTypes.string.isRequired,


### PR DESCRIPTION
Closes https://github.com/michealengland/micheal-dev/issues/53

This PR fixes two minor issues which resolves #53 
- Fix name on component propType declaration for TextLink
- Add missing propType

## How to Verify
1. Checkout this branch and run `gatsby develop`
2. Branch should build without linter issue